### PR TITLE
Fix Pusher errors

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -27,8 +27,8 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 //     broadcaster: 'pusher',
 //     key: process.env.MIX_PUSHER_APP_KEY,
 //     wsHost: process.env.MIX_PUSHER_HOST ?? `ws-${process.env.MIX_PUSHER_CLUSTER}.pusher.com`,
-//     wsPort: process.env.MIX_PUSHER_PORT ?? 80,
-//     wssPort: process.env.MIX_PUSHER_PORT ?? 443,
+//     wsPort: parseInt(process.env.MIX_PUSHER_PORT ?? 80),
+//     wssPort: parseInt(process.env.MIX_PUSHER_PORT ?? 443),
 //     forceTLS: (process.env.MIX_PUSHER_SCHEME ?? 'https') === 'https',
 //     enabledTransports: ['ws', 'wss'],
 // });

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -29,6 +29,6 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 //     wsHost: process.env.MIX_PUSHER_HOST ?? `ws-${process.env.MIX_PUSHER_CLUSTER}.pusher.com`,
 //     wsPort: process.env.MIX_PUSHER_PORT ?? 80,
 //     wssPort: process.env.MIX_PUSHER_PORT ?? 443,
-//     forceTLS: (proces.env.MIX_PUSHER_SCHEME ?? 'https') === 'https',
+//     forceTLS: (process.env.MIX_PUSHER_SCHEME ?? 'https') === 'https',
 //     enabledTransports: ['ws', 'wss'],
 // });


### PR DESCRIPTION
Process typo & pusher-js is squeaking because env variable is passing as a string.